### PR TITLE
Fix label spacing

### DIFF
--- a/assets/stylesheets/common/roblox-profile.scss
+++ b/assets/stylesheets/common/roblox-profile.scss
@@ -1,0 +1,4 @@
+// Add right margin to website link on profile page
+.user-main .about .details .primary .primary-textual .location-and-website .user-profile-website {
+    margin-right: 1em;
+}

--- a/plugin.rb
+++ b/plugin.rb
@@ -3,3 +3,5 @@
 # authors: boyned/Kampfkarren, buildthomas
 
 enabled_site_setting :roblox_profile_enabled
+
+register_asset "stylesheets/common/roblox-profile.scss"


### PR DESCRIPTION
Solves https://github.com/roblox-dev-forum/roblox-profile/issues/4.
Added 1em right margin to website link; identical rule already exists on location label. 
Seems to look alright on mobile.

Alternative solution is to change the rule to always add 1em right margin to direct children of `.location-and-website`.
```css
.user-main .about .details .primary .primary-textual .location-and-website > * {
  margin-right: 1em;
}
```

---

I have no way to test this right now, but I'm assuming I can just plop a stylesheet in by following the directory structure used in other plugins. 