### PR TITLE
Replace Roblox logo IMG with color-responsive SVG

### DIFF
--- a/assets/javascripts/discourse/templates/connectors/user-card-metadata/roblox-profile.hbs
+++ b/assets/javascripts/discourse/templates/connectors/user-card-metadata/roblox-profile.hbs
@@ -1,6 +1,8 @@
 {{#if siteSettings.roblox_profile_enabled}}
     <div>
-        <img src="https://roblox.com/favicon.ico" style="width: 12px">
+        <svg class="svg-icon svg-icon-title" viewBox="0 0 65 65">
+        	<path xmlns="http://www.w3.org/2000/svg" d="M21,9.3L9.2,55.1L55,66.9l11.8-45.8L21,9.3z M41.3,43.7l-8.9-2.3l2.3-8.9l8.9,2.3L41.3,43.7z"></path>
+        </svg>
         <a href="https://www.roblox.com/users/profile?username={{user.username}}">Roblox Profile</a>
     </div>
 {{/if}}

--- a/assets/javascripts/discourse/templates/connectors/user-location-and-website/roblox-profile.hbs
+++ b/assets/javascripts/discourse/templates/connectors/user-location-and-website/roblox-profile.hbs
@@ -1,6 +1,8 @@
 {{#if siteSettings.roblox_profile_enabled}}
     <span>
-        <img src="https://roblox.com/favicon.ico" style="width: 12px">
+        <svg class="svg-icon svg-icon-title" viewBox="0 0 65 65">
+        	<path xmlns="http://www.w3.org/2000/svg" d="M21,9.3L9.2,55.1L55,66.9l11.8-45.8L21,9.3z M41.3,43.7l-8.9-2.3l2.3-8.9l8.9,2.3L41.3,43.7z"></path>
+        </svg>
         <a href="https://www.roblox.com/users/profile?username={{model.username}}">Roblox Profile</a>
     </span>
 {{/if}}


### PR DESCRIPTION
Solves https://github.com/roblox-dev-forum/roblox-profile/issues/7.

SVG is hardcoded and duplicated because it's small. Uses built-in Discourse CSS to change color according to theme: `.svg-icon.svg-icon-title`. It should match all other website icons automatically.

![image](https://user-images.githubusercontent.com/26800119/71532963-bf32e300-28bb-11ea-99a5-dcf0c9ebd224.png)
